### PR TITLE
Fallback to the current site URL if none is provided

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -133,6 +133,10 @@ function get_endpoint(): string {
 	$url = defined( 'AMF_WORDPRESS_URL' ) ? AMF_WORDPRESS_URL : get_option( URL_SETTING, '' );
 	$url = sanitize_wordpress_url( $url );
 
+	if ( empty( $url ) ) {
+		$url = home_url();
+	}
+
 	$endpoint = "{$url}/wp-json/wp/v2/media";
 
 	return $endpoint;


### PR DESCRIPTION
When setting this up on a new site where no URL has been entered on the settings screen and no `AMF_WORDPRESS_URL` constant is defined, the WordPress HTTP API returns an error stating `A valid URL was not provided`. This is because an empty string is used as the URL. This ultimately causes the infinite media spinner of doom.

This fixes that by falling back to the current site URL if none has been otherwise defined, allowing this to "just work" out of the box.