### PR TITLE
Cast the `meta` field of the REST API response to an array

### DIFF
--- a/inc/class-factory.php
+++ b/inc/class-factory.php
@@ -36,7 +36,8 @@ class Factory {
 		$item = $this->create_item( $data );
 
 		if ( $data->meta ) {
-			$item->set_meta( array_merge( $data->meta, $item->meta ) );
+			$data_meta = json_decode( json_encode( $data->meta ), true );
+			$item->set_meta( array_merge( $data_meta, $item->meta ) );
 		}
 
 		$attachment_metadata = $this->get_attachment_metadata( $data );


### PR DESCRIPTION
The `Factory::create()` method receives the raw REST API response in its `stdClass $data` parameter. The `meta` property of this response is itself a `stdClass`, not an array, therefore it fatals when it's passed into `array_merge()`.

This change implements the JSON encode/decode method to convert it, the same as 85375ce.