### PR TITLE
Remove the remote HTTP connection to fetch the filesize

### DIFF
--- a/inc/class-factory.php
+++ b/inc/class-factory.php
@@ -68,8 +68,6 @@ class Factory {
 			$item->set_modified( strtotime( $data->modified ) );
 		}
 
-		$item->set_file_size( $this->get_file_size( $data->source_url ) );
-
 		$featured_media_url = $this->get_featured_media_url( $data );
 		if ( $featured_media_url ) {
 			$item->set_image( $featured_media_url );
@@ -240,23 +238,6 @@ class Factory {
 	private function get_featured_media_url( stdClass $data ): string {
 
 		return (string) ( $data->_embedded->{'wp:featuredmedia'}[0]->source_url ?? '' );
-	}
-
-	/**
-	 * Get the remote file's size without downloading the full file.
-	 *
-	 * @param string $url Target URL.
-	 *
-	 * @return int File size in bytes.
-	 */
-	private function get_file_size( string $url ): int {
-
-		$headers = get_headers( $url, 1 ) ?: [];
-		$headers = array_change_key_case( $headers );
-
-		$file_size = (int) ( $headers['content-length'] ?? 0 );
-
-		return $file_size;
 	}
 
 	/**


### PR DESCRIPTION
The performance of this plugin on my local Altis site was at a crawl. Each request to the attachments query Ajax endpoint was taking 20-30 seconds.

I narrowed down the problem to this call to `get_headers()`. It's called for each file in the result and performs a server side HTTP request to the URL in order to fetch its size. I can see that the file size is not exposed in the WordPress REST API, which I guess is the reason this code exists.

Removing this call brings the performance back to acceptable levels.

Removing this means the `File size:` section in the media manager contains no value, but this is a fair tradeoff to bring the performance back.

Regarding exposing the file size, we could:

* Open a WordPress core ticket to get the file size added to the REST API response, or
* Add an extra field to the REST API response via this plugin which would solve the problem for a Multisite network

In the meantime I propose simply removing this.