### PR TITLE
fix: check for media_details before setting values

### DIFF
--- a/inc/class-factory.php
+++ b/inc/class-factory.php
@@ -167,11 +167,11 @@ class Factory {
 
 		$item = new Image( $data->id, $data->mime_type );
 		
-		if ( isset($data->media_details->width)) {
+		if ( isset( $data->media_details->width ) ) {
 		   $item->set_width( $data->media_details->width );
 		}
 		
-		if ( isset($data->media_details->height)) {
+		if ( isset( $data->media_details->height ) ) {
 		   $item->set_width( $data->media_details->height );
 		}
 

--- a/inc/class-factory.php
+++ b/inc/class-factory.php
@@ -166,9 +166,14 @@ class Factory {
 	public function create_image( stdClass $data ): Image {
 
 		$item = new Image( $data->id, $data->mime_type );
-
-		$item->set_width( $data->media_details->width );
-		$item->set_height( $data->media_details->height );
+		
+		if ( isset($data->media_details->width)) {
+		   $item->set_width( $data->media_details->width );
+		}
+		
+		if ( isset($data->media_details->height)) {
+		   $item->set_width( $data->media_details->height );
+		}
 
 		return $item;
 	}


### PR DESCRIPTION
#### Problem
It appears a `TypeError` is thrown by this file every now and then
![image](https://user-images.githubusercontent.com/6068672/119882724-b7d29780-befc-11eb-90cd-7a8f658d8d88.png)

#### Description
checks for media_details before setting the width and height